### PR TITLE
Bump placeholderapi from 2.10.2 to 2.10.9

### DIFF
--- a/bukkit/pom.xml
+++ b/bukkit/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
-            <version>2.10.2</version>
+            <version>2.10.9</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Bumps placeholderapi from 2.10.2 to 2.10.9.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>